### PR TITLE
Created custom patch files for Telephony-KMOD

### DIFF
--- a/telephony-kmods/dahdi_5_14_kernel.patch
+++ b/telephony-kmods/dahdi_5_14_kernel.patch
@@ -1,0 +1,199 @@
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/dahdi-base.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/dahdi-base.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/dahdi-base.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/dahdi-base.c	2023-01-17 12:04:18.322695859 +0000
+@@ -82,8 +82,8 @@
+ 
+ #include "hpec/hpec_user.h"
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/voicebus/vpmoct.h dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/voicebus/vpmoct.h
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/voicebus/vpmoct.h	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/voicebus/vpmoct.h	2023-01-17 12:05:24.898090118 +0000
+@@ -30,8 +30,8 @@
+ #include <linux/timer.h>
+ #include "dahdi/kernel.h"
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wcaxx-base.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wcaxx-base.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcaxx-base.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcaxx-base.c	2023-01-17 12:06:40.423537377 +0000
+@@ -34,8 +34,8 @@
+ #include <linux/firmware.h>
+ #include <linux/crc32.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wct4xxp/base.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wct4xxp/base.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wct4xxp/base.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wct4xxp/base.c	2023-01-17 12:07:07.844699764 +0000
+@@ -42,8 +42,8 @@
+ #include <linux/crc32.h>
+ #include <linux/slab.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wct4xxp/vpm450m.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wct4xxp/vpm450m.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wct4xxp/vpm450m.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wct4xxp/vpm450m.c	2023-01-17 12:07:42.161902989 +0000
+@@ -29,8 +29,8 @@
+ 
+ #include <dahdi/kernel.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wctc4xxp/base.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wctc4xxp/base.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wctc4xxp/base.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wctc4xxp/base.c	2023-01-17 12:08:58.352354186 +0000
+@@ -40,8 +40,8 @@
+ #include <linux/timer.h>
+ #include <dahdi/kernel.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wctdm24xxp/base.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wctdm24xxp/base.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wctdm24xxp/base.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wctdm24xxp/base.c	2023-01-17 12:09:23.762504664 +0000
+@@ -54,8 +54,8 @@
+ #include <linux/crc32.h>
+ #include <linux/slab.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wcte13xp-base.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wcte13xp-base.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcte13xp-base.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcte13xp-base.c	2023-01-17 12:09:50.183661130 +0000
+@@ -36,8 +36,8 @@
+ #include <linux/crc32.h>
+ #include <dahdi/kernel.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wcte43x-base.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wcte43x-base.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcte43x-base.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcte43x-base.c	2023-01-17 12:10:10.378780724 +0000
+@@ -43,8 +43,8 @@
+ #include <linux/firmware.h>
+ #include <oct612x.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wcxb.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wcxb.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcxb.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcxb.c	2023-01-17 12:10:26.880878451 +0000
+@@ -36,8 +36,8 @@
+ 
+ #include <dahdi/kernel.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wcxb_spi.h dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wcxb_spi.h
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcxb_spi.h	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wcxb_spi.h	2023-01-17 12:10:41.896967376 +0000
+@@ -26,8 +26,8 @@
+ #include <linux/spi/spi.h>
+ #include <linux/version.h>
+ 
+-/* Linux kernel 5.16 and greater has removed user-space headers from the kernel include path */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++/* Linux kernel 5.14 and greater has removed user-space headers from the kernel include path */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #include <asm/types.h>
+ #else
+ #include <stdbool.h>
+
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/xpp/xbus-core.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/xpp/xbus-core.c
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/xpp/xbus-core.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/xpp/xbus-core.c	2023-01-19 15:04:55.465060629 +0000
+@@ -1839,7 +1839,7 @@
+ 
+ static int xbus_read_proc_open(struct inode *inode, struct file *file)
+ {
+-	return single_open(file, xbus_proc_show, PDE_DATA(inode));
++	return single_open(file, xbus_proc_show, pde_data(inode));
+ }
+ 
+ #ifdef DAHDI_HAVE_PROC_OPS
+@@ -1946,7 +1946,7 @@
+ 
+ static int proc_xbus_command_open(struct inode *inode, struct file *file)
+ {
+-	file->private_data = PDE_DATA(inode);
++	file->private_data = pde_data(inode);
+ 	return 0;
+ }
+ 
+@@ -1989,7 +1989,7 @@
+ 
+ static int xpp_proc_read_open(struct inode *inode, struct file *file)
+ {
+-	return single_open(file, xpp_proc_read_show, PDE_DATA(inode));
++	return single_open(file, xpp_proc_read_show, pde_data(inode));
+ }
+ 
+ #ifdef DAHDI_HAVE_PROC_OPS
+
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/include/dahdi/kernel.h dahdi-linux-complete-3.2.0+3.2.0-b/linux/include/dahdi/kernel.h
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/include/dahdi/kernel.h	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/include/dahdi/kernel.h	2023-01-25 16:39:54.152534164 +0000
+@@ -1488,7 +1488,7 @@
+ #endif /* 4.15.0 */
+ #endif /* 5.6 */
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+ #ifdef CONFIG_PROC_FS
+ #define PDE_DATA(i)	pde_data(i)
+ #endif
+

--- a/telephony-kmods/telephony-kmods.spec
+++ b/telephony-kmods/telephony-kmods.spec
@@ -10,12 +10,12 @@
 %endif
 
 %if 0%{?el9}
-%{!?kmod_kernel_version: %define kmod_kernel_version 5.14.0-162.6.1.el9_1} 
+%{!?kmod_kernel_version: %define kmod_kernel_version 5.14.0-162.12.1.el9_1} 
 %endif
 
 Name:		telephony-kmods
 Version:	1.0
-Release:	9%{?dist}
+Release:	10%{?dist}
 Summary:	Telephony kernel modules
 License:	GPLv2
 URL:		http://www.kernel.org/
@@ -24,6 +24,8 @@ URL:		http://www.kernel.org/
 Source0:	dahdi-linux-complete-%{dahdi_version}+%{dahdi_version}.tar.gz
 Source1:	ftp://ftp.sangoma.com/wanpipe-%{wanpipe_version}.tgz
 Patch1:		wanpipe-7.0.34-state.patch
+Patch2:         wanpipe-7.0.34-state-el9.patch
+Patch3:         dahdi_5_14_kernel.patch
 
 ExclusiveArch:	x86_64
 
@@ -95,6 +97,10 @@ of the same variant of the Linux kernel and not on any one specific build.
 %prep
 %setup -c -a 1
 %patch1 -p1
+%if 0%{?el9}
+%patch2 -p1
+%patch3 -p1
+%endif
 
 echo "override dahdi * weak-updates/dahdi" > dahdi-linux-complete-%{dahdi_version}+%{dahdi_version}/linux/kmod-dahdi.conf
 echo "override wanpipe * weak-updates/wanpipe" > wanpipe-%{wanpipe_version}/kmod-wanpipe.conf
@@ -233,6 +239,9 @@ exit 0
 
 
 %changelog
+* Thu Jan 26 2023 Patrick Coakley <patrick.coakley@spearline.com> - 1.0-10
+- Created custom patches for dahdi and wanpipe to work with Kernel 5.14.0-162.12.1.el9_1
+
 * Wed Jan 18 2023 Patrick Coakley <patrick.coakley@spearline.com> - 1.0-9
 - Upgraded Kernel version to 4.18.0-425.10.1.el8_7 for SpearlineOS 8.7.4
 

--- a/telephony-kmods/wanpipe-7.0.34-state-el9.patch
+++ b/telephony-kmods/wanpipe-7.0.34-state-el9.patch
@@ -1,0 +1,39 @@
+diff -ru wanpipe-7.0.34-a/patches/kdrivers/include/wanpipe_kernel.h wanpipe-7.0.34-b/patches/kdrivers/include/wanpipe_kernel.h
+--- telephony-kmods-a/wanpipe-7.0.34/patches/kdrivers/include/wanpipe_kernel.h	2008-08-01 14:00:00.000000000 +0100
++++ telephony-kmods-b/wanpipe-7.0.34/patches/kdrivers/include/wanpipe_kernel.h	2023-01-25 16:56:03.517431918 +0000
+@@ -286,15 +286,20 @@
+ 
+  #define dev_init_buffers(a)
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
++#define PDE_DATA(i)	pde_data(i)
++#endif
++
++
+  #if defined(KERN_PROC_PDE_FEATURE) && KERN_PROC_PDE_FEATURE > 0
+- # define WP_PDE_DATA PDE_DATA
++ # define WP_PDE_DATA pde_data
+  #else 
+  #include <linux/proc_fs.h>
+  static inline void*WP_PDE_DATA(const struct inode *inode)
+  {	
+-	struct proc_dir_entry* pde=PDE(inode);
++	struct proc_dir_entry* pde=PDE_DATA(inode);
+ 	if (pde) {
+-		return pde->data;
++		return PDE_DATA(inode);
+ 	}	
+     
+ 	return NULL;
+
+--- telephony-kmods-a/wanpipe-7.0.34/patches/kdrivers/include/wanpipe_wanrouter.h	2008-08-01 14:00:00.000000000 +0100
++++ telephony-kmods-b/wanpipe-7.0.34/patches/kdrivers/include/wanpipe_wanrouter.h	2023-01-26 15:29:07.093000835 +0000
+@@ -336,8 +336,6 @@
+ 	
+ 	wan_get_info_t*	get_dev_config_info;
+ 	wan_get_info_t*	get_if_info;
+-	write_proc_t*	set_dev_config;
+-	write_proc_t*	set_if_info;
+ #endif
+ 
+ 	int 	(*get_info)(void*, struct seq_file* m, int *);


### PR DESCRIPTION
`dahdi` and `wanpipe` were giving multiple errors with 9.1

The majority of the errors were related to `PDE_DATA` now being declared by its lowercase form `pde_data`

`dahdi_5_14_kernel.patch` & `wanpipe-7.0.34-state.patch` are custom patch files created to get `telephony_kmod` to build for SpearlineOS 9.1

Signed: Patrick Coakley