### PR TITLE
Changing kernel version for el8.8

### DIFF
--- a/kmod-hpsa-el8/hpsa-kmod.spec
+++ b/kmod-hpsa-el8/hpsa-kmod.spec
@@ -2,13 +2,13 @@
 %define kmod_name		hpsa
 
 # If kmod_kernel_version isn't defined on the rpmbuild line, define it here.
-%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-425.13.1.el8_7}
+%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-477.10.1.el8_8}
 
 %{!?dist: %define dist .el8}
 
 Name:		kmod-%{kmod_name}
 Version:	3.4.20
-Release:	11%{?dist}
+Release:	12%{?dist}
 Summary:	%{kmod_name} kernel module(s)
 Group:		System Environment/Kernel
 License:	GPLv2
@@ -119,6 +119,9 @@ done
 %doc /usr/share/doc/kmod-%{kmod_name}-%{version}/
 
 %changelog
+* Thu May 18 2023 Patrick Coakley <patrick.coakley@cyara.com> - 3.4.20-12
+- Updated for CyaraOS 8.8 
+
 * Mon Mar 27 2023 Patrick Coakley <patrick.coakley@spearline.com> - 3.4.20-11
 - Updated for SpearlineOS 8.7.8
 

--- a/kmod-megaraid_sas-el8/megaraid_sas-kmod.spec
+++ b/kmod-megaraid_sas-el8/megaraid_sas-kmod.spec
@@ -2,13 +2,13 @@
 %define kmod_name		megaraid_sas
 
 # If kmod_kernel_version isn't defined on the rpmbuild line, define it here.
-%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-425.13.1.el8_7}
+%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-477.10.1.el8_8}
 
 %{!?dist: %define dist .el8}
 
 Name:		kmod-%{kmod_name}
 Version:	07.719.03.00
-Release:	5%{?dist}
+Release:	6%{?dist}
 Summary:	%{kmod_name} kernel module(s)
 Group:		System Environment/Kernel
 License:	GPLv2
@@ -115,6 +115,9 @@ find %{buildroot} -name \*.ko -type f | xargs --no-run-if-empty %{__strip} --str
 %doc /usr/share/doc/kmod-%{kmod_name}-%{version}/
 
 %changelog
+* Thu May 18 2023 Patrick Coakley <patrick.coakley@cyara.com> - 07.719.03.00-6
+- Updated for CyaraOS 8.8 
+
 * Mon Mar 27 2023 Patrick Coakley <patrick.coakley@spearline.com> - 07.719.03.00-5
 - Updated for SpearlineOS 8.7.8
 

--- a/kmod-sata_sil-el8/sata_sil-kmod.spec
+++ b/kmod-sata_sil-el8/sata_sil-kmod.spec
@@ -2,13 +2,13 @@
 %define kmod_name		sata_sil
 
 # If kmod_kernel_version isn't defined on the rpmbuild line, define it here.
-%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-425.13.1.el8_7}
+%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-477.10.1.el8_8}
 
 %{!?dist: %define dist .el8}
 
 Name:           kmod-%{kmod_name}
 Version:        2.4
-Release:        10%{?dist}
+Release:        11%{?dist}
 Summary:        %{kmod_name} kernel module(s)
 Group:          System Environment/Kernel
 License:        GPLv2
@@ -121,6 +121,9 @@ find %{buildroot} -type f -name \*.ko -exec %{__strip} --strip-debug \{\} \;
 %doc /usr/share/doc/kmod-%{kmod_name}-%{version}/
 
 %changelog
+* Thu May 18 2023 Patrick Coakley <patrick.coakley@cyara.com> - 2.4-11
+- Updated for CyaraOS 8.8 
+
 * Mon Mar 27 2023 Patrick Coakley <patrick.coakley@spearline.com> - 2.4-10
 - Updated for SpearlineOS 8.7.8
 

--- a/kmod-wireguard-el8/elrepo-wireguard-backports.el8_7.patch
+++ b/kmod-wireguard-el8/elrepo-wireguard-backports.el8_7.patch
@@ -19,3 +19,16 @@ diff -Naurp wireguard-linux-compat-1.0.20220627.orig/src/compat/compat.h wiregua
  #include <linux/ktime.h>
  #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)
  #include <linux/hrtimer.h>
+
+--- wireguard-linux-compat-1.0.20220627/src/peer.c	2022-06-27 11:54:37.000000000 +0100
++++ wireguard-linux-compat-1.0.20220627/src/peer.c	2023-05-18 16:20:17.263779220 +0100
+@@ -54,7 +54,7 @@
+ 	skb_queue_head_init(&peer->staged_packet_queue);
+ 	wg_noise_reset_last_sent_handshake(&peer->last_sent_handshake);
+ 	set_bit(NAPI_STATE_NO_BUSY_POLL, &peer->napi.state);
+-	netif_napi_add(wg->dev, &peer->napi, wg_packet_rx_poll,
++	netif_napi_add_weight(wg->dev, &peer->napi, wg_packet_rx_poll,
+ 		       NAPI_POLL_WEIGHT);
+ 	napi_enable(&peer->napi);
+ 	list_add_tail(&peer->peer_list, &wg->peer_list);
+

--- a/kmod-wireguard-el8/wireguard-kmod.spec
+++ b/kmod-wireguard-el8/wireguard-kmod.spec
@@ -2,13 +2,11 @@
 %define kmod_name		wireguard
 
 # If kmod_kernel_version isn't defined on the rpmbuild line, define it here.
-%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-425.13.1.el8_7}
-
-%{!?dist: %define dist .el8}
+%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-477.10.1.el8_8}
 
 Name:		kmod-%{kmod_name}
 Version:	1.0.20220627
-Release:	6%{?dist}
+Release:	7%{?dist}
 Summary:	%{kmod_name} kernel module(s)
 Group:		System Environment/Kernel
 License:	GPLv2
@@ -114,6 +112,9 @@ done
 %doc /usr/share/doc/kmod-%{kmod_name}-%{version}/
 
 %changelog
+* Thu May 18 2023 Patrick Coakley <patrick.coakley@cyara.com> - 1.0.20220627-7
+- Updated for CyaraOS 8.8 
+
 * Mon Mar 27 2023 Patrick Coakley <patrick.coakley@spearline.com> - 1.0.20220627-6
 - Updated for SpearlineOS 8.7.8
 

--- a/telephony-kmods/dahdi_el8_8_kernel.patch
+++ b/telephony-kmods/dahdi_el8_8_kernel.patch
@@ -1,0 +1,12 @@
+diff -ru dahdi-linux-complete-3.2.0+3.2.0-a/linux/drivers/dahdi/wctc4xxp/base.c dahdi-linux-complete-3.2.0+3.2.0-b/linux/drivers/dahdi/wctc4xxp/base.c 
+--- telephony-kmods-a/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wctc4xxp/base.c	2022-09-22 13:23:24.000000000 +0100
++++ telephony-kmods-b/dahdi-linux-complete-3.2.0+3.2.0/linux/drivers/dahdi/wctc4xxp/base.c	2023-05-18 14:37:24.918334554 +0100
+@@ -658,7 +658,7 @@
+ 	netdev->promiscuity = 0;
+ 	netdev->flags |= IFF_NOARP;
+ 
+-	netif_napi_add(netdev, &wc->napi, &wctc4xxp_poll, 64);
++	netif_napi_add_weight(netdev, &wc->napi, &wctc4xxp_poll, 64);
+ 
+ 	res = register_netdev(netdev);
+ 	if (res) {

--- a/telephony-kmods/telephony-kmods.spec
+++ b/telephony-kmods/telephony-kmods.spec
@@ -6,7 +6,7 @@
 
 # If kmod_kernel_version isn't defined on the rpmbuild line, define it here.
 %if 0%{?el8}
-%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-425.13.1.el8_7}
+%{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-477.10.1.el8_8}
 %endif
 
 %if 0%{?el9}
@@ -15,7 +15,7 @@
 
 Name:		telephony-kmods
 Version:	1.0
-Release:	11%{?dist}
+Release:	12%{?dist}
 Summary:	Telephony kernel modules
 License:	GPLv2
 URL:		http://www.kernel.org/
@@ -26,7 +26,7 @@ Source1:	ftp://ftp.sangoma.com/wanpipe-%{wanpipe_version}.tgz
 Patch1:		wanpipe-7.0.34-state.patch
 Patch2:         wanpipe-7.0.34-state-el9.patch
 Patch3:         dahdi_5_14_kernel.patch
-
+Patch4:         dahdi_el8_8_kernel.patch
 ExclusiveArch:	x86_64
 
 # Source code patches
@@ -100,6 +100,9 @@ of the same variant of the Linux kernel and not on any one specific build.
 %if 0%{?el9}
 %patch2 -p1
 %patch3 -p1
+%endif
+%if 0%{?el8}
+%patch4 -p1
 %endif
 
 echo "override dahdi * weak-updates/dahdi" > dahdi-linux-complete-%{dahdi_version}+%{dahdi_version}/linux/kmod-dahdi.conf
@@ -239,6 +242,9 @@ exit 0
 
 
 %changelog
+* Thu May 18 2023 Patrick Coakley <patrick.coakley@cyara.com> - 1.0-12
+- Updated for CyaraOS 8.8 
+
 * Mon Mar 27 2023 Patrick Coakley <patrick.coakley@spearline.com> - 1.0-11
 - Created custom patches for dahdi and wanpipe to work with Kernel 4.18.0-425.13.1.el8_7
 

--- a/telephony-kmods/wanpipe-7.0.34-state.patch
+++ b/telephony-kmods/wanpipe-7.0.34-state.patch
@@ -19,3 +19,24 @@ diff --no-dereference -urb wanpipe-7.0.34/patches/kdrivers/src/wanrouter/af_wanp
  	remove_wait_queue(WAN_SK_SLEEP(sk),&wait);
  
  	if (err != 0)
+--- telephony-kmods-a/wanpipe-7.0.34/patches/kdrivers/src/wanrouter/af_wanpipe.c	2021-09-15 12:28:06.000000000 +0100
++++ telephony-kmods-b/wanpipe-7.0.34/patches/kdrivers/src/wanrouter/af_wanpipe.c	2023-05-15 12:19:01.291519266 +0100
+@@ -238,7 +238,7 @@
+ 					AF_SKB_DEC(skb->truesize);
+ 					skb_free_datagram(sk, skb);
+ 				}
+-				while ((skb=skb_recv_datagram(sk,0,1,&err)) != NULL){
++				while ((skb=skb_recv_datagram(sk,0,&err)) != NULL){
+ 					AF_SKB_DEC(skb->truesize);
+ 					skb_free_datagram(sk, skb);
+ 				}
+@@ -1688,7 +1688,7 @@
+ 	if (flags & MSG_OOB){	
+ 		skb=skb_dequeue(&sk->sk_error_queue);
+ 	}else{
+-		skb=skb_recv_datagram(sk,flags,1,&err);
++		skb=skb_recv_datagram(sk,flags,&err);
+ 	}
+ 	/*
+ 	 *	An error occurred so return it. Because skb_recv_datagram() 
+


### PR DESCRIPTION
This PR is to build the KMODS to be compatible with CyaraOS after upgrading it to build off AlmaLinux 8.8

Custom Patches:
1. Had to create netif_napi_add_weight patch for wireguard & dahdi
2. Had to create skb=skb_recv_datagram patch for wanpipe

All kmods have built successfully on copr 
https://copr.fedorainfracloud.org/coprs/jdieter/slos/builds/


Signed: Patrick Coakley